### PR TITLE
Fix sed command

### DIFF
--- a/script/rename_template_app
+++ b/script/rename_template_app
@@ -13,11 +13,11 @@ mv src/lucky_jumpstart.cr src/$NEW_APP_NAME.cr
 print_done
 
 notice "Renaming instances of template 'lucky_jumpstart' value"
-grep --exclude-dir=script -rl "lucky_jumpstart" * | xargs sed -i "" "s/lucky_jumpstart/$NEW_APP_NAME/g"
+grep --exclude-dir=script -rl "lucky_jumpstart" * | xargs sed -i "s/lucky_jumpstart/$NEW_APP_NAME/g"
 print_done
 
 notice "Renaming instances of template 'Lucky Jumpstart' value"
-grep --exclude-dir=script -rl "Lucky Jumpstart" * | xargs sed -i "" "s/Lucky Jumpstart/$NEW_APP_NAME/g"
+grep --exclude-dir=script -rl "Lucky Jumpstart" * | xargs sed -i "s/Lucky Jumpstart/$NEW_APP_NAME/g"
 print_done
 
 notice "Committing changes to git"


### PR DESCRIPTION
When trying to rename the app, I'm encountering the following error with sed:
```
➜  alexandria git:(master) ./script/rename_template_app alexandria

▸ Renaming 'src/lucky_jumpstart.cr'
  ✔ Done

▸ Renaming instances of template 'lucky_jumpstart' value
sed: can't read s/lucky_jumpstart/alexandria/g: No such file or directory
```
 This PR fixes the problem, removing the useless `""` in the the sed command.