### PR TITLE
Add configuration for fly.io deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ There are quite a few things I find myself adding to every Lucky application out
 
 - 🐳 &nbsp; [Docker](https://www.docker.com), which enables any Dockerfile-based deployment like:
   - [Render](https://render.com)
+  - [fly.io](https://fly.io)
   - [Digital Ocean Apps Platform](https://www.digitalocean.com/products/app-platform)
 - 🟩 &nbsp; [Render](https://render.com) with a built-in `render.yaml` file
+- 🎈 &nbsp; [Fly.io](https://fly.io) with a built-in `fly.toml` file
 - 👾 &nbsp; [Heroku](https://luckyframework.org/guides/deploying/heroku) with a built-in `Procfile` file

--- a/dockerfiles/fly.Dockerfile
+++ b/dockerfiles/fly.Dockerfile
@@ -1,0 +1,45 @@
+# Install the application Crystal dependencies
+FROM crystallang/crystal:1.3.2-alpine as crystal_dependencies
+ENV LUCKY_ENV=production
+ENV SKIP_LUCKY_TASK_PRECOMPILATION=1
+WORKDIR /shards
+COPY shard.yml shard.override.yml shard.lock ./
+RUN  shards install --production
+
+# Install the application Yarn dependencies, then compile production CSS/JS
+FROM node:alpine as asset_build
+WORKDIR /assets
+COPY . .
+RUN yarn install
+RUN yarn prod
+
+# Build the Lucky tasks binary
+FROM crystallang/crystal:1.3.2-alpine as lucky_tasks_build
+ENV LUCKY_ENV=production
+RUN apk --no-cache add yaml-static
+COPY . .
+COPY --from=crystal_dependencies /shards/lib lib
+COPY --from=asset_build /assets/public public
+RUN crystal build --static --release tasks.cr -o /usr/local/bin/lucky
+
+# Build the webserver binary
+FROM crystallang/crystal:1.3.2-alpine as lucky_webserver_build
+WORKDIR /webserver_build
+RUN apk --no-cache add yaml-static
+ENV LUCKY_ENV=production
+COPY . .
+COPY --from=crystal_dependencies /shards/lib lib
+COPY --from=asset_build /assets/public public
+RUN shards build --production --static --release
+RUN mv ./bin/webserver /usr/local/bin/webserver
+
+# Serve the application binary
+FROM alpine as webserver
+WORKDIR /app
+RUN apk --no-cache add postgresql-client tzdata
+COPY --from=lucky_tasks_build /usr/local/bin/lucky /usr/local/bin/lucky
+COPY --from=lucky_webserver_build /usr/local/bin/webserver webserver
+COPY --from=asset_build /assets/public public
+
+ENV PORT 8080
+CMD ["./webserver"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,59 @@
+app = "lucky-jumpstart"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  dockerfile = "dockerfiles/fly.Dockerfile"
+
+[deploy]
+  release_command = "lucky db.migrate"
+
+[env]
+  LUCKY_ENV = "production"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 50
+    soft_limit = 40
+    type = "connections"
+
+  [[services.http_checks]]
+    grace_period = "5s"
+    interval = 10000
+    method = "get"
+    path = "/ping"
+    protocol = "http"
+    timeout = 2000
+    tls_skip_verify = false
+
+    [services.http_checks.headers]
+      X-Forwarded-Proto = "https"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[[statics]]
+  guest_path = "/app/public"
+  url_prefix = "/"

--- a/src/actions/ping/index.cr
+++ b/src/actions/ping/index.cr
@@ -1,0 +1,9 @@
+class Ping::Index < BrowserAction
+  include Auth::AllowGuests
+
+  get "/ping" do
+    return head 503 if Avram::Migrator::Runner.migrations.any?(&.new.pending?)
+
+    head 200
+  end
+end


### PR DESCRIPTION
We don't need to do replacement in .jumpstart/init.cr because
fly deploy forces users to pick a name that overrides this value
